### PR TITLE
remove filters for import

### DIFF
--- a/R/data_import.R
+++ b/R/data_import.R
@@ -36,14 +36,6 @@ import_sensor <- function(list_sensor){
       # we select the data that we don't consider null (arbitrary choice)
       import <- load(file)
       import <- get(import)
-      import <- import %>% filter(.data$uptime > 0.5,
-                                           .data$heavy_lft + .data$car_lft + .data$pedestrian_lft + .data$bike_lft +
-                                             .data$heavy_rgt + .data$car_rgt + .data$pedestrian_rgt + .data$bike_rgt >0)
-      import$car_speed_hist_0to70plus <-  convert_string_to_list(import$car_speed_hist_0to70plus)
-      import$car_speed_hist_0to120plus <- convert_string_to_list(import$car_speed_hist_0to120plus)
-      import$date <- ymd_hms(import$date)
-
-
       import
     } else {
       message(paste('No data stored for', .x))


### PR DESCRIPTION
When importing data from saved records, filters are applied even though we want to retrieve the data as it was at the time of saving. Specifically, we want to keep the data with uptime < 0.5. This PR aims to remove these filters.